### PR TITLE
Fix blog page spacing to match layout

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -108,7 +108,7 @@ export default async function PostPage({
       : null;
 
   return (
-    <main className="container mx-auto flex min-h-screen max-w-3xl flex-col gap-4 p-8">
+    <main className="flex min-h-screen flex-col gap-4 pb-20 pt-8">
       <JsonLd data={articleSchema} />
       {faqSchema && <JsonLd data={faqSchema} />}
       <Link href="/blog" className="hover:underline">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -44,7 +44,7 @@ export default async function IndexPage({ searchParams }: PageProps<"/blog">) {
   ]);
 
   return (
-    <main className="container mx-auto min-h-screen max-w-3xl p-8">
+    <main className="flex min-h-screen flex-col pb-20 pt-8">
       <Link
         href="/"
         className="mb-4 inline-block text-sm text-gray-600 hover:underline"


### PR DESCRIPTION
## Summary
- remove redundant container width limits from the blog listing and article pages so they inherit the global layout spacing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f38d4ebf28832b9b5a6c5b896f3d53