### PR TITLE
Enhance global and blog metadata for SEO

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -25,22 +25,92 @@ import { format } from "date-fns";
 import { pl } from "date-fns/locale";
 import { JsonLd } from "@/components/JsonLd";
 import type { BlogPosting, FAQPage, Question, WithContext } from "schema-dts";
+import {
+  DEFAULT_KEYWORDS,
+  DEFAULT_OG_IMAGE,
+  SITE_NAME,
+  SITE_URL,
+} from "@/lib/siteMetadata";
+
+const options = { next: { revalidate: 30 } };
+const { projectId, dataset } = client.config();
+
+const urlFor = (source: SanityImageSource) =>
+  projectId && dataset
+    ? imageUrlBuilder({ projectId, dataset }).image(source)
+    : null;
+
+const buildPostImageUrl = (image: SanityImageSource | undefined) =>
+  image ? urlFor(image)?.width(1600).height(900).auto("format").url() ?? null : null;
 
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
+  const resolvedParams = await params;
   const post = await client.fetch<SanityDocument>(
     POST_QUERY,
-    await params,
+    resolvedParams,
     options
   );
 
+  const canonicalPath = post?.slug?.current
+    ? `/blog/${post.slug.current}`
+    : "/blog";
+  const generatedImageUrl = buildPostImageUrl(post?.image);
+  const postImageUrl = generatedImageUrl ?? DEFAULT_OG_IMAGE;
+  const pageTitle = post?.title ? String(post.title) : SITE_NAME;
+  const description =
+    post?.excerpt || "Przeczytaj artykuł na blogu Kalkulatora Dni Roboczych";
+  const keywords = post?.title
+    ? [...DEFAULT_KEYWORDS, String(post.title)]
+    : DEFAULT_KEYWORDS;
+
+  const openGraphImages = generatedImageUrl
+    ? [
+        {
+          url: generatedImageUrl,
+          width: 1600,
+          height: 900,
+          alt: pageTitle,
+        },
+      ]
+    : [
+        {
+          url: DEFAULT_OG_IMAGE,
+          width: 512,
+          height: 512,
+          alt: SITE_NAME,
+        },
+      ];
+
   return {
-    title: `${post.title} - Kalkulator Dni Roboczych`,
-    description:
-      post.excerpt || "Przeczytaj artykuł na blogu Kalkulatora Dni Roboczych",
+    title: pageTitle,
+    description,
+    keywords,
+    alternates: {
+      canonical: canonicalPath,
+    },
+    authors: [{ name: SITE_NAME, url: SITE_URL }],
+    openGraph: {
+      type: "article",
+      url: canonicalPath,
+      title: pageTitle,
+      description,
+      siteName: SITE_NAME,
+      locale: "pl_PL",
+      publishedTime: post?.publishedAt,
+      modifiedTime: post?._updatedAt ?? post?.publishedAt,
+      images: openGraphImages,
+      authors: [SITE_NAME],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: pageTitle,
+      description,
+      images: [postImageUrl],
+    },
   };
 }
 
@@ -53,38 +123,30 @@ const POST_QUERY = `*[_type == "post" && slug.current == $slug][0]{
   }
 }`;
 
-const { projectId, dataset } = client.config();
-const urlFor = (source: SanityImageSource) =>
-  projectId && dataset
-    ? imageUrlBuilder({ projectId, dataset }).image(source)
-    : null;
-
-const options = { next: { revalidate: 30 } };
-
 export default async function PostPage({
   params,
 }: {
   params: Promise<{ slug: string }>;
 }) {
+  const resolvedParams = await params;
   const post = await client.fetch<SanityDocument>(
     POST_QUERY,
-    await params,
+    resolvedParams,
     options
   );
-  const postImageUrl = post.image
-    ? urlFor(post.image)?.width(1600).height(900).auto("format").url()
-    : null;
+  const postImageUrl = buildPostImageUrl(post.image);
 
   const articleSchema = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     headline: post.title,
     datePublished: post.publishedAt,
+    dateModified: post._updatedAt ?? post.publishedAt,
     image: postImageUrl ? [postImageUrl] : [],
     author: {
       "@type": "Organization",
-      name: "Kalkulator Dni Roboczych",
-      url: "https://kalkulatordniroboczych.pl",
+      name: SITE_NAME,
+      url: SITE_URL,
     },
   } satisfies WithContext<BlogPosting>;
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,10 +1,15 @@
+import { Metadata } from "next";
 import Link from "next/link";
 import { type SanityDocument } from "next-sanity";
 import { format } from "date-fns";
 import { pl } from "date-fns/locale";
 
 import { client } from "@/lib/sanity/client";
-import { Metadata } from "next";
+import {
+  DEFAULT_KEYWORDS,
+  DEFAULT_OG_IMAGE,
+  SITE_NAME,
+} from "@/lib/siteMetadata";
 import {
   Pagination,
   PaginationContent,
@@ -15,10 +20,38 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination";
 
+const pageTitle = "Blog Kalkulator Dni Roboczych";
+const pageDescription =
+  "Na blogu znajdziesz praktyczne informacje dotyczące dni roboczych, planowania pracy oraz ciekawostki związane z kalendarzem. Sprawdź nasze najnowsze wpisy!";
+
 export const metadata: Metadata = {
-  title: "Blog Kalkulator Dni Roboczych",
-  description:
-    "Na blogu znajdziesz praktyczne informacje dotyczące dni roboczych, planowania pracy oraz ciekawostki związane z kalendarzem. Sprawdź nasze najnowsze wpisy!",
+  title: { absolute: pageTitle },
+  description: pageDescription,
+  keywords: [...DEFAULT_KEYWORDS, "blog dni roboczych", "porady o pracy"],
+  alternates: {
+    canonical: "/blog",
+  },
+  openGraph: {
+    type: "website",
+    url: "/blog",
+    title: pageTitle,
+    description: pageDescription,
+    siteName: SITE_NAME,
+    images: [
+      {
+        url: DEFAULT_OG_IMAGE,
+        width: 512,
+        height: 512,
+        alt: SITE_NAME,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: pageTitle,
+    description: pageDescription,
+    images: [DEFAULT_OG_IMAGE],
+  },
 };
 
 const POSTS_PER_PAGE = 5;
@@ -98,7 +131,6 @@ export default async function IndexPage({ searchParams }: PageProps<"/blog">) {
                 {[...Array(Math.ceil(totalCount / POSTS_PER_PAGE))].map(
                   (_, i) => {
                     const pageNumber = i + 1;
-                    // Show first page, last page, and pages around current page
                     if (
                       pageNumber === 1 ||
                       pageNumber === Math.ceil(totalCount / POSTS_PER_PAGE) ||

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,81 @@
-import BaseLayout from "../components/BaseLayout";
-import "./globals.css";
-import GoogleAnalytics from "../components/GoogleAnalytics";
-
+import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import Adsense from "@/components/Adsense";
 
-// If loading a variable font, you don't need to specify the font weight
+import Adsense from "@/components/Adsense";
+import BaseLayout from "../components/BaseLayout";
+import GoogleAnalytics from "../components/GoogleAnalytics";
+import "./globals.css";
+import {
+  DEFAULT_DESCRIPTION,
+  DEFAULT_KEYWORDS,
+  DEFAULT_OG_IMAGE,
+  SITE_NAME,
+  SITE_URL,
+} from "@/lib/siteMetadata";
+
 const inter = Inter({
   subsets: ["latin"],
   display: "swap",
 });
+
+export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: SITE_NAME,
+    template: "%s | " + SITE_NAME,
+  },
+  description: DEFAULT_DESCRIPTION,
+  keywords: DEFAULT_KEYWORDS,
+  authors: [{ name: SITE_NAME, url: SITE_URL }],
+  creator: SITE_NAME,
+  publisher: SITE_NAME,
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    locale: "pl_PL",
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    title: SITE_NAME,
+    description: DEFAULT_DESCRIPTION,
+    images: [
+      {
+        url: DEFAULT_OG_IMAGE,
+        width: 512,
+        height: 512,
+        alt: SITE_NAME,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_NAME,
+    description: DEFAULT_DESCRIPTION,
+    images: [DEFAULT_OG_IMAGE],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      maxSnippet: -1,
+      maxImagePreview: "large",
+      maxVideoPreview: -1,
+    },
+  },
+  manifest: "/site.webmanifest",
+  icons: {
+    icon: [
+      { url: "/favicon-32x32.png", sizes: "32x32", type: "image/png" },
+      { url: "/favicon-16x16.png", sizes: "16x16", type: "image/png" },
+      { url: "/favicon.ico", type: "image/x-icon" },
+    ],
+    apple: "/apple-touch-icon.png",
+  },
+  referrer: "origin-when-cross-origin",
+};
 
 export default function RootLayout({
   children,
@@ -21,9 +87,7 @@ export default function RootLayout({
       <GoogleAnalytics />
       <Adsense />
       <body>
-        {/* <Providers> */}
         <BaseLayout>{children}</BaseLayout>
-        {/* </Providers> */}
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,50 @@
 import { Metadata } from "next";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
+
 import ClosestHoliday from "../components/ClosestHoliday";
 import Recommended from "../components/Recommended";
 import WorkDaysCalculator from "../components/WorkDaysCalculator";
+import {
+  DEFAULT_KEYWORDS,
+  DEFAULT_OG_IMAGE,
+  SITE_NAME,
+} from "@/lib/siteMetadata";
 
 const currentYear: number = new Date().getFullYear();
 
+const pageTitle = `Kalkulator Dni Roboczych ${currentYear}`;
+const pageDescription =
+  "Skorzystaj z kalkulatora dni roboczych, aby policzyć liczbę dni pracy pomiędzy dowolnymi datami lub wyznaczyć termin zakończenia odliczając dni robocze.";
+
 export const metadata: Metadata = {
-  title: `Kalkulator Dni Roboczych ${currentYear}`,
-  description:
-    "Dzięki kalkulatorowi dowiesz się ile jest dni roboczych pomiędzy dwoma podanymi datami lub kiedy wypada data końcowa od określonej liczby dni roboczych. Policz dni robocze!",
-  robots: "index, follow",
+  title: { absolute: pageTitle },
+  description: pageDescription,
+  keywords: [...DEFAULT_KEYWORDS, `dni robocze ${currentYear}`],
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    url: "/",
+    title: pageTitle,
+    description: pageDescription,
+    siteName: SITE_NAME,
+    images: [
+      {
+        url: DEFAULT_OG_IMAGE,
+        width: 512,
+        height: 512,
+        alt: SITE_NAME,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: pageTitle,
+    description: pageDescription,
+    images: [DEFAULT_OG_IMAGE],
+  },
 };
 
 const Page = () => {

--- a/src/lib/siteMetadata.ts
+++ b/src/lib/siteMetadata.ts
@@ -1,0 +1,12 @@
+export const SITE_URL = "https://kalkulatordniroboczych.pl";
+export const SITE_NAME = "Kalkulator Dni Roboczych";
+export const DEFAULT_DESCRIPTION =
+  "Kalkulator dni roboczych pomagający szybko obliczyć liczbę dni pracy pomiędzy wybranymi datami wraz z dodatkowymi poradami i narzędziami.";
+export const DEFAULT_KEYWORDS = [
+  "kalkulator dni roboczych",
+  "dni pracujące",
+  "ile dni roboczych",
+  "planowanie pracy",
+  "terminy biznesowe",
+];
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/android-chrome-512x512.png`;


### PR DESCRIPTION
## Summary
- centralize shared site metadata and establish rich defaults in the root layout
- expand homepage and blog index metadata with canonical URLs and social previews
- enrich blog post metadata generation with canonical links, Open Graph/Twitter cards, and article schema updates

## Testing
- pnpm lint *(fails: existing lint violations in cloudflare-env.d.ts, jest.config.js, mdx-components.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68f3ebcdb084832baecf2c54f1771cfc