### PR TITLE
Use latest Node 22 release in manual deploy workflow

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,46 @@
+name: Manual Deploy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy on demand
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NEXT_PUBLIC_GA_TRACKING_ID: ${{ vars.NEXT_PUBLIC_GA_TRACKING_ID }}
+      NEXT_PUBLIC_GOOGLE_ADSENSE: ${{ vars.NEXT_PUBLIC_GOOGLE_ADSENSE }}
+      SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
+      SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.16.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create environment file
+        run: |
+          cat <<EOT > .env
+          NEXT_PUBLIC_GA_TRACKING_ID=${NEXT_PUBLIC_GA_TRACKING_ID}
+          NEXT_PUBLIC_GOOGLE_ADSENSE=${NEXT_PUBLIC_GOOGLE_ADSENSE}
+          SANITY_PROJECT_ID=${SANITY_PROJECT_ID}
+          SANITY_DATASET=${SANITY_DATASET}
+          EOT
+
+      - name: Deploy
+        run: pnpm run deploy


### PR DESCRIPTION
## Summary
- adjust the manual deploy workflow to install the latest available Node.js 22 release via actions/setup-node so the setup step succeeds

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f3efe2bb24832ba3502d5cc2d43673