### PR TITLE
Fix manual deploy workflow pnpm setup

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- switch the manual deploy workflow to install pnpm via corepack instead of pnpm/action-setup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f3f5f47970832bb998f9e888bfb962